### PR TITLE
Use a relative path when accessing assets.

### DIFF
--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,7 +2,7 @@
   <div class="header">
     <h1 id="title" class="title">ember-validatable-inputs</h1>
     <a target="_blank" rel="noopener" href="https://github.com/HallDJack/ember-validatable-input">
-      <img class="octocat" alt="github octocat" src="/assets/Octocat.png">
+      <img class="octocat" alt="github octocat" src="assets/Octocat.png">
     </a>
   </div>
 </header>


### PR DESCRIPTION
A relative path is required for the asset to work when deployed to GitHub pages.